### PR TITLE
Scroll bar color changed from #0a09034b to #f72585 to match the accen…

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -32,7 +32,7 @@ header ::selection,
 }
 
 ::-webkit-scrollbar-thumb {
-	background: #0a09034b;
+	background: #f72585;
 	border-radius: 2em;
 	cursor: pointer;
 }


### PR DESCRIPTION
Scroll bar color changed from #0a09034b to #f72585 to match the accent of the website and Fix UX issue 
![Screenshot from 2021-10-07 08-11-16](https://user-images.githubusercontent.com/40488244/136312191-df4114b9-7662-4dd3-8970-353f7c104c5b.png)
![Screenshot from 2021-10-07 08-11-27](https://user-images.githubusercontent.com/40488244/136312194-b45efb21-5fa5-4a2d-bcdc-ea577c9280c5.png)

